### PR TITLE
Migrating Payload service provider to Funky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Ngob
+Copyright (c) 2016-2017 Ngob
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.1",
         "oscarotero/psr7-middlewares": "^3.0",
-        "container-interop/service-provider": "~0.3.0",
+        "thecodingmachine/funky": "^1",
         "container-interop/container-interop": "^1.0",
         "thecodingmachine/middleware-list-universal-module": "~1.0"
     },
@@ -22,5 +22,7 @@
         "psr-4": {
             "PsCs\\UniversalModule\\Psr7Middlewares\\Middleware\\": "src/"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/PayloadServiceProvider.php
+++ b/src/PayloadServiceProvider.php
@@ -2,35 +2,20 @@
 
 namespace PsCs\UniversalModule\Psr7Middlewares\Middleware;
 
-use Interop\Container\ServiceProvider;
-use Interop\Container\ContainerInterface as Container;
 use Psr7Middlewares\Middleware\Payload;
+use TheCodingMachine\Funky\Annotations\Factory;
+use TheCodingMachine\Funky\Annotations\Tag;
+use TheCodingMachine\Funky\ServiceProvider;
 use TheCodingMachine\MiddlewareListServiceProvider;
 use TheCodingMachine\MiddlewareOrder;
 
-class PayloadServiceProvider implements ServiceProvider
+class PayloadServiceProvider extends ServiceProvider
 {
-    public function getServices()
-    {
-        return [
-        Payload::class => [ self::class, 'createPayload' ],
-        MiddlewareListServiceProvider::MIDDLEWARES_QUEUE => [self::class, 'updatePriorityQueue'],
-    ];
-    }
-
+    /**
+     * @Factory(tags={@Tag(name=MiddlewareListServiceProvider::MIDDLEWARES_QUEUE, priority=MiddlewareOrder::UTILITY_EARLY)})
+     */
     public static function createPayload() : Payload
     {
         return new Payload();
-    }
-
-    public static function updatePriorityQueue(Container $container, callable $previous = null) : \SplPriorityQueue
-    {
-        if ($previous) {
-            $priorityQueue = $previous();
-            $priorityQueue->insert($container->get(Payload::class), MiddlewareOrder::UTILITY_EARLY);
-            return $priorityQueue;
-        } else {
-            throw new \InvalidArgumentException("Could not find declaration for service '".MiddlewareListServiceProvider::MIDDLEWARES_QUEUE."'.");
-        }
     }
 }


### PR DESCRIPTION
This PR migrates from container-interop/service-provider 0.3 to Funky.
Funky provides support for container-interop/service-provider 0.4 (and hopefully also for the next releases to come).